### PR TITLE
Don't store one ETS entry for each entity

### DIFF
--- a/glass_backend/src/glass_query_server.erl
+++ b/glass_backend/src/glass_query_server.erl
@@ -59,6 +59,7 @@ handle_cast(Msg, State) ->
 
 
 run_search(Workspace, Query, Node, Id) ->
+  io:format("*** Searching ~p~n", [Workspace]),
   Entities = glass_index_server:get_entities(Workspace, function),
   State = #search_state{
     workspace = Workspace,
@@ -68,7 +69,8 @@ run_search(Workspace, Query, Node, Id) ->
   lists:foreach(fun({EntityId, Form, Meta}) ->
                   Results = glass_query:unify(Query, Form),
                   publish(State, {EntityId, Form, Meta}, Results)
-                end, Entities).
+                end, Entities),
+  io:format("*** Search completed.~n").
 
 publish(State, Form, Results) ->
   lists:foreach(fun(Result) -> publish_result(State, Form, Result) end, Results).

--- a/glass_backend/src/glass_report.erl
+++ b/glass_backend/src/glass_report.erl
@@ -7,7 +7,7 @@
 on_result(_Workspace, _Id, Form, {_Env, Match}) ->
   show(Form, Match).
 
-show({{function, {Name, Arity}}, Form, Meta}, Match) ->
+show({{_, _, _, {function, {Name, Arity}}}, Form, Meta}, Match) ->
   FormLine = glass_ast:get_line(Form),
   ErlangAst = case glass_ast:glass_to_node(Match) of
                 Nodes when is_list(Nodes) -> Nodes;


### PR DESCRIPTION
Selecting ETS entries is very expensive without more work on making proper indexes for them, so this makes the current iteration unusably slow for large codebases. Storing a list of entries per workspace is reasonable when the querying algorithm  itself isn't very optimised, but it's not incremental, so this isn't a final solution.